### PR TITLE
[Fix] Capture area on non primary display is not working

### DIFF
--- a/src-tauri/src/model/screenshot_capture.rs
+++ b/src-tauri/src/model/screenshot_capture.rs
@@ -12,13 +12,23 @@ pub fn capture_entire_sreen() -> Image {
 
 #[inline(always)]
 pub fn capture_area(area_top_left: (i32, i32), area_bottom_right: (i32, i32)) -> Image {
-    let display_info = DisplayInfo::from_point(0, 0).unwrap();
+    let display_info = DisplayInfo::from_point(area_top_left.0, area_top_left.1).unwrap();
     let screen = Screen::new(&display_info);
+
+    // for multi screen support
+    // screen.capture_area() requires the axis from target screen's top left
+    // so I need to re-calculate capture area position
+    let display_top_left: (i32, i32) = (display_info.x, display_info.y);
 
     let width: u32 = (area_bottom_right.0 - area_top_left.0).try_into().unwrap();
     let height: u32 = (area_bottom_right.1 - area_top_left.1).try_into().unwrap();
     let image = screen
-        .capture_area(area_top_left.0, area_top_left.1, width, height)
+        .capture_area(
+            area_top_left.0 - display_top_left.0,
+            area_top_left.1 - display_top_left.1,
+            width,
+            height,
+        )
         .unwrap();
     return image;
 }


### PR DESCRIPTION
Now sub-display analyze works

## Fix
- Use capture area top left axis as selector of display